### PR TITLE
Fix for Unknown prop  on <pre> tag.

### DIFF
--- a/JSONPretty.jsx
+++ b/JSONPretty.jsx
@@ -26,7 +26,9 @@ module.exports = React.createClass({
         .replace(regLine, this._replace);
   },
   render: function () {
-    var json = this.props.json;
+
+    // See https://facebook.github.io/react/warnings/unknown-prop.html
+    var { json, ...rest } = this.props;
 
     if (typeof json === 'string') {
       try {
@@ -38,7 +40,7 @@ module.exports = React.createClass({
     }
 
     return (
-      <pre {...this.props} className='json-pretty' dangerouslySetInnerHTML={{__html: this._pretty(json)}}>
+      <pre {...rest} className='json-pretty' dangerouslySetInnerHTML={{__html: this._pretty(json)}}>
       </pre>
     );
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "npm run build-styl && npm run build-jsx",
     "build-styl": "stylus --compress < JSONPretty.monikai.styl > src/JSONPretty.monikai.css",
-    "build-jsx": "babel JSONPretty.jsx -d src"
+    "build-jsx": "babel --presets es2015 --plugins 'transform-object-rest-spread' JSONPretty.jsx -d src"
   },
   "keywords": [
     "react",
@@ -25,12 +25,13 @@
     "babel-cli": "~6.3.17",
     "babel-core": "^6.3.26",
     "babel-loader": "^6.2.0",
+    "babel-plugin-transform-object-rest-spread": "^6.8.0",
+    "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.3.13",
     "stylus": "^0.53.0"
   },
-  "repository":
-  {
-    "type" : "git",
-    "url" : "https://github.com/chenckang/react-json-pretty"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chenckang/react-json-pretty"
   }
 }

--- a/src/JSONPretty.js
+++ b/src/JSONPretty.js
@@ -1,4 +1,8 @@
+'use strict';
+
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
 var React = require('react');
 
@@ -6,7 +10,7 @@ module.exports = React.createClass({
   displayName: 'exports',
 
   // 格式化函数
-  _replace: function (match, ind, key, val, tra) {
+  _replace: function _replace(match, ind, key, val, tra) {
     var spanEnd = '</span>';
     var keySpan = '<span class=json-key>';
     var valSpan = '<span class=json-value>';
@@ -21,13 +25,18 @@ module.exports = React.createClass({
     return sps + (tra || '');
   },
   // JSON =》 HTML转换器
-  _pretty: function (obj) {
+  _pretty: function _pretty(obj) {
     // 逐行匹配，列举：“key”: "value" | "key": value | "key": [ | "key": { | "key": [],| "Key": {},
     var regLine = /^( *)("[^"]+": )?("[^"]*"|[\w.+-]*)?([,[{]|\[\s*\],?|\{\s*\},?)?$/mg;
     return JSON.stringify(obj, null, 2).replace(/&/g, '&amp;').replace(/\\"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(regLine, this._replace);
   },
-  render: function () {
-    var json = this.props.json;
+  render: function render() {
+
+    // See https://facebook.github.io/react/warnings/unknown-prop.html
+    var _props = this.props;
+    var json = _props.json;
+
+    var rest = _objectWithoutProperties(_props, ['json']);
 
     if (typeof json === 'string') {
       try {
@@ -37,6 +46,6 @@ module.exports = React.createClass({
       }
     }
 
-    return React.createElement('pre', _extends({}, this.props, { className: 'json-pretty', dangerouslySetInnerHTML: { __html: this._pretty(json) } }));
+    return React.createElement('pre', _extends({}, rest, { className: 'json-pretty', dangerouslySetInnerHTML: { __html: this._pretty(json) } }));
   }
 });


### PR DESCRIPTION
React `^15.0.1` produces the following error in console:

```
warning.js:44 Warning: Unknown prop `json` on <pre> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
```

This is due to the 'json' property being passed blindly through to the pre.

Removed the 'json' property once used, so it is not passed through.

Had to add in the transform-object-rest-spread plugin, and the es2015 preset to destruct the splat cleanly.

`npm run build` performed successfully, though I haven't checked in the node_modules folder due to .gitignore settings.

Hence you will need to perform an `npm install` before running.
