### PR TITLE
Add react as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "author": "chenckang@gmail.com",
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "react": "^0.14.3"
   },
   "devDependencies": {


### PR DESCRIPTION
If this package works with react 15 it would be very handy to add the react
version as a peer dependency to have the dependent supply the version of react.
In this case react 0.14 would be not installed in an app which is using react 15.
Currently it installs the react 0.14 additionally because it is not a peer dependency.
It would be nice to avoid having to different react versions installed in the dependency tree.

Just for reference: https://lexi-lambda.github.io/blog/2016/08/24/understanding-the-npm-dependency-model/