### PR TITLE
fix (Warnings): Fix deprecated warnings when using react 15.6.2 due to wildcard import

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   ],
   "scripts": {
     "test": "jest --verbose=true --coverage",
-    "build": "mkdir -p dist && mkdir -p themes && npm run build-styl && npm run build-jsx",
+    "build": "run-script-os",
+    "build:win32": "npm run build-styl && npm run build-jsx",
+    "build:default": "mkdir -p dist && mkdir -p themes && npm run build-styl && npm run build-jsx",
     "lint": "tslint --project tsconfig.json --config tslint.json './src/**/*.tsx'",
     "precommit": "npm run build && npm run lint",
     "prepush": "npm test",
@@ -25,6 +27,11 @@
     "build-styl-adventure": "stylus --compress < src/adventure_time.styl > themes/adventure_time.css",
     "build-styl": "npm run build-styl-monikai && npm run build-styl-1337 && npm run build-styl-acai && npm run build-styl-adventure",
     "build-jsx": "tsc -p tsconfig.json"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run precommit"
+    }
   },
   "keywords": [
     "react",
@@ -42,21 +49,22 @@
   "devDependencies": {
     "@types/enzyme": "^3.1.15",
     "@types/enzyme-adapter-react-16": "^1.0.3",
-    "@types/jest": "^23.3.11",
+    "@types/jest": "^24.0.18",
     "@types/prop-types": "^15.5.8",
     "@types/react": "^16.7.18",
     "@types/react-dom": "^16.0.11",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.9.1",
     "enzyme-to-json": "^3.3.5",
-    "husky": "^1.3.1",
+    "husky": "^3.0.5",
     "jest": "^24.5.0",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-test-renderer": "^16.7.0",
+    "run-script-os": "^1.0.7",
     "standard-version": "^4.4.0",
     "stylus": "^0.54.5",
-    "ts-jest": "^23.10.5",
+    "ts-jest": "^24.1.0",
     "tslint": "^5.12.0",
     "typescript": "^3.2.2",
     "webpack": "^4.28.3"

--- a/src/JSONPretty.tsx
+++ b/src/JSONPretty.tsx
@@ -1,5 +1,5 @@
-import * as PropTypes from 'prop-types';
-import * as React from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 interface ITheme {[key: string]: string; }
 interface IProps {


### PR DESCRIPTION
Fix deprecated warning when using react 15.6.2 due to wildcard import
* (Accessing PropTypes via the main React, Accessing createClass via the main React)
* Update ts-jest to 24 to remove test warning about being incompatible with jest 24.
* Allow build to run on windows as well (run-script-os, mkdir -p on windows is invalid.)